### PR TITLE
remove the desktop file for networkmanager_dmenu

### DIFF
--- a/applications/network_manager_dmenu.desktop
+++ b/applications/network_manager_dmenu.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Name=NetworkManager dmenu (patched)
-Comment=TODO
-Keywords=TODO
-Exec=/usr/bin/networkmanager_dmenu -i -c -l 20 -bw 5 -fn "mononoki Nerd Font-20"
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
-Terminal=false
-Type=Application


### PR DESCRIPTION
This PR removes the custom `.desktop` for `networkmanager_dmenu`.
As this application is installed through the AUR, the default `.desktop` file is already installed when using the [`PKGBUILD`](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=networkmanager-dmenu-git) :ok_hand: 