### PR TITLE
FIX: add the correct new path to the `.desktop` icon

### DIFF
--- a/applications/ani_cli.desktop
+++ b/applications/ani_cli.desktop
@@ -4,6 +4,6 @@ Name=ani-cli
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/ani-cli -q 480
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/cava.desktop
+++ b/applications/cava.desktop
@@ -4,6 +4,6 @@ Name=cava
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/cava
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/clock.desktop
+++ b/applications/clock.desktop
@@ -4,6 +4,6 @@ Name=clock
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/termdown -z
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/moc.desktop
+++ b/applications/moc.desktop
@@ -4,6 +4,6 @@ Name=mocp
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/mocp
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/ncdu.desktop
+++ b/applications/ncdu.desktop
@@ -4,6 +4,6 @@ Name=ncdu
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/ncdu -x /
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/network_manager_dmenu.desktop
+++ b/applications/network_manager_dmenu.desktop
@@ -4,6 +4,6 @@ Name=NetworkManager dmenu (patched)
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/networkmanager_dmenu -i -c -l 20 -bw 5 -fn "mononoki Nerd Font-20"
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=false
 Type=Application

--- a/applications/passmenu.desktop
+++ b/applications/passmenu.desktop
@@ -4,6 +4,6 @@ Name=passmenu
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/passmenu -c -l 10 -bw 5 -fn "mononoki Nerd Font-20"
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=false
 Type=Application

--- a/applications/ptpython.desktop
+++ b/applications/ptpython.desktop
@@ -4,6 +4,6 @@ Name=ptpython
 Comment=TODO
 Keywords=TODO
 Exec=$HOME/.local/bin/ptpython
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/pulsemixer.desktop
+++ b/applications/pulsemixer.desktop
@@ -4,6 +4,6 @@ Name=pulsemixer
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/pulsemixer
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/qshell.desktop
+++ b/applications/qshell.desktop
@@ -4,6 +4,6 @@ Name=qtile shell
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/qtile shell
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/rofi_bluetooth.desktop
+++ b/applications/rofi_bluetooth.desktop
@@ -4,6 +4,6 @@ Name=rofi-bluetooth
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/rofi-bluetooth
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=false
 Type=Application

--- a/applications/shell.desktop
+++ b/applications/shell.desktop
@@ -4,6 +4,6 @@ Name=shell
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/fish %u
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=true
 Type=Application

--- a/applications/surf.desktop
+++ b/applications/surf.desktop
@@ -4,6 +4,6 @@ Name=surf
 Comment=TODO
 Keywords=TODO
 Exec=/usr/bin/tabbed -c surf -N -e %u
-Icon=/usr/share/icons/amtoine-icons-git/dark/128x128/misc/ok.png
+Icon=/usr/share/icons/goat-icons-git/dark/128x128/misc/ok.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
This PR fixes the path to the goat icons.

Related to the changes introduced in [pkgbuilds#25](https://github.com/goatfiles/pkgbuilds/pull/25)